### PR TITLE
Determine specific versions of Mac OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ target/
 
 # IntelliJ
 .idea/
-jos.iml
+*.iml
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/src/main/java/io/github/cegredev/josi/OS.java
+++ b/src/main/java/io/github/cegredev/josi/OS.java
@@ -48,16 +48,16 @@ public enum OS {
 
 	// Specific versions of macOS. Originally named MAC OS X, it was renamed to macOS starting
 	// with Sierra.
-	MAC_OSX_CHEETAH(Family.MAC), MAC_OSX_PUMA(Family.MAC), MAC_OSX_JAGUAR(Family.MAC),
-	MAC_OSX_PANTHER(Family.MAC), MAC_OSX_TIGER(Family.MAC), MAC_OSX_LEOPARD(Family.MAC),
-	MAC_OSX_SNOW_LEOPARD(Family.MAC), MAC_OSX_LION(Family.MAC), MAC_OSX_MOUNTAIN_LION(Family.MAC),
-	MAC_OSX_MAVERICKS(Family.MAC), MAC_OSX_YOSEMITE(Family.MAC), MAC_OSX_EL_CAPITAN(Family.MAC),
-	MAC_OS_SIERRA(Family.MAC), MAC_OS_HIGH_SIERRA(Family.MAC), MAC_OS_MOJAVE(Family.MAC),
-	MAC_OS_CATALINA(Family.MAC), MAC_OS_BIG_SUR(Family.MAC),
+	MAC_OSX_CHEETAH(MAC), MAC_OSX_PUMA(MAC), MAC_OSX_JAGUAR(MAC),
+	MAC_OSX_PANTHER(MAC), MAC_OSX_TIGER(MAC), MAC_OSX_LEOPARD(MAC),
+	MAC_OSX_SNOW_LEOPARD(MAC), MAC_OSX_LION(MAC), MAC_OSX_MOUNTAIN_LION(MAC),
+	MAC_OSX_MAVERICKS(MAC), MAC_OSX_YOSEMITE(MAC), MAC_OSX_EL_CAPITAN(MAC),
+	MAC_OS_SIERRA(MAC), MAC_OS_HIGH_SIERRA(MAC), MAC_OS_MOJAVE(MAC),
+	MAC_OS_CATALINA(MAC), MAC_OS_BIG_SUR(MAC),
 	/**
 	 * Any Mac based operating system.
 	 */
-	MAC(Family.MAC),
+	MAC_UNKNOWN(MAC),
 	/**
 	 * Any Linux based operating system.
 	 */
@@ -135,7 +135,7 @@ public enum OS {
 
 			if (versionSplit.length < 2) {
 				// If we only have the major version, we can't decide
-				return MAC;
+				return MAC_UNKNOWN;
 			}
 
 			String majorMinor = versionSplit[0] + "." + versionSplit[1];
@@ -174,12 +174,14 @@ public enum OS {
 				case "10.15":
 					return MAC_OS_CATALINA;
 				case "10.16":
+					// Even though Big Sur is macOS version 11.x,
+					// the os.version system property returns 10.16
 					return MAC_OS_BIG_SUR;
 				default:
 					break;
 			}
 
-			return MAC;
+			return MAC_UNKNOWN;
 		}
 
 		// Decide Linux version
@@ -517,7 +519,7 @@ public enum OS {
 		/**
 		 * The MacOS operating system family.
 		 */
-		MAC(() -> OS.MAC),
+		MAC(() -> OS.MAC_OS_BIG_SUR),
 		/**
 		 * Any Linux based operating system family.
 		 */

--- a/src/main/java/io/github/cegredev/josi/OS.java
+++ b/src/main/java/io/github/cegredev/josi/OS.java
@@ -45,6 +45,15 @@ public enum OS {
 	 * An unknown or at least unrecognizable Windows based operating system.
 	 */
 	WIN_UNKNOWN(WINDOWS),
+
+	// Specific versions of macOS. Originally named MAC OS X, it was renamed to macOS starting
+	// with Sierra.
+	MAC_OSX_CHEETAH(Family.MAC), MAC_OSX_PUMA(Family.MAC), MAC_OSX_JAGUAR(Family.MAC),
+	MAC_OSX_PANTHER(Family.MAC), MAC_OSX_TIGER(Family.MAC), MAC_OSX_LEOPARD(Family.MAC),
+	MAC_OSX_SNOW_LEOPARD(Family.MAC), MAC_OSX_LION(Family.MAC), MAC_OSX_MOUNTAIN_LION(Family.MAC),
+	MAC_OSX_MAVERICKS(Family.MAC), MAC_OSX_YOSEMITE(Family.MAC), MAC_OSX_EL_CAPITAN(Family.MAC),
+	MAC_OS_SIERRA(Family.MAC), MAC_OS_HIGH_SIERRA(Family.MAC), MAC_OS_MOJAVE(Family.MAC),
+	MAC_OS_CATALINA(Family.MAC), MAC_OS_BIG_SUR(Family.MAC),
 	/**
 	 * Any Mac based operating system.
 	 */
@@ -61,7 +70,7 @@ public enum OS {
 	/**
 	 * The operating system running on the current PC.
 	 */
-	private static final OS CURRENT = determine(System.getProperty("os.name"));
+	private static final OS CURRENT = determine(System.getProperty("os.name"), System.getProperty("os.version"));
 
 	/**
 	 * The family the operating system belongs to.
@@ -80,10 +89,12 @@ public enum OS {
 	 *
 	 * @param name The name to determine the operating system from. Expects values in the format of {@code
 	 *             System.getProperty("os.name")}.
+	 * @param version The version to determine the operating system from. Expects values in the format of {@code
+	 * 	              System.getProperty("os.version")}.
 	 * @return An operating system matching the given name or other if the name can not be recognized.
 	 */
-	static OS determine(String name) {
-		// TODO: Implement Mac and Linux in more detail
+	static OS determine(String name, String version) {
+		// TODO: Implement Linux in more detail
 
 		// Locale.ROOT prevents funny locale stuff from happening
 		name = name.toLowerCase(Locale.ROOT).trim();
@@ -120,6 +131,54 @@ public enum OS {
 
 		// Decide Mac version
 		if (name.startsWith("mac")) {
+			String[] versionSplit = version.split("\\.");
+
+			if (versionSplit.length < 2) {
+				// If we only have the major version, we can't decide
+				return MAC;
+			}
+
+			String majorMinor = versionSplit[0] + "." + versionSplit[1];
+
+			switch (majorMinor) {
+				case "10.0":
+					return MAC_OSX_CHEETAH;
+				case "10.1":
+					return MAC_OSX_PUMA;
+				case "10.2":
+					return MAC_OSX_JAGUAR;
+				case "10.3":
+					return MAC_OSX_PANTHER;
+				case "10.4":
+					return MAC_OSX_TIGER;
+				case "10.5":
+					return MAC_OSX_LEOPARD;
+				case "10.6":
+					return MAC_OSX_SNOW_LEOPARD;
+				case "10.7":
+					return MAC_OSX_LION;
+				case "10.8":
+					return MAC_OSX_MOUNTAIN_LION;
+				case "10.9":
+					return MAC_OSX_MAVERICKS;
+				case "10.10":
+					return MAC_OSX_YOSEMITE;
+				case "10.11":
+					return MAC_OSX_EL_CAPITAN;
+				case "10.12":
+					return MAC_OS_SIERRA;
+				case "10.13":
+					return MAC_OS_HIGH_SIERRA;
+				case "10.14":
+					return MAC_OS_MOJAVE;
+				case "10.15":
+					return MAC_OS_CATALINA;
+				case "10.16":
+					return MAC_OS_BIG_SUR;
+				default:
+					break;
+			}
+
 			return MAC;
 		}
 

--- a/src/test/java/io/github/cegredev/josi/OSCheckTests.java
+++ b/src/test/java/io/github/cegredev/josi/OSCheckTests.java
@@ -31,24 +31,24 @@ public class OSCheckTests {
 
 	@Test
 	public void testIsOS() {
-		assertTrue(OS.WIN_10.is(OS.WIN_95, OS.WIN_10, OS.MAC), "OS was not recognized!");
-		assertFalse(OS.WIN_8.is(OS.WIN_95, OS.WIN_10, OS.MAC), "OS was not recognized!");
+		assertTrue(OS.WIN_10.is(OS.WIN_95, OS.WIN_10, OS.MAC_UNKNOWN), "OS was not recognized!");
+		assertFalse(OS.WIN_8.is(OS.WIN_95, OS.WIN_10, OS.MAC_UNKNOWN), "OS was not recognized!");
 	}
 
 	@Test
 	public void testIsFamily() {
 		assertTrue(OS.WIN_10.isFamily(OS.Family.WINDOWS, OS.Family.MAC), "OS family was not recognized!");
-		assertFalse(OS.MAC.isFamily(OS.Family.LINUX, OS.Family.OTHER), "OS family was not recognized!");
+		assertFalse(OS.MAC_UNKNOWN.isFamily(OS.Family.LINUX, OS.Family.OTHER), "OS family was not recognized!");
 	}
 
 	@Test
 	public void testEnforceOS() {
 		assertDoesNotThrow(() -> OS.WIN_10.enforce(OS.WIN_95, OS.WIN_10), "Threw even though OS was allowed!");
-		assertThrows(UnsupportedOSException.class, () -> OS.MAC.enforce(OS.WIN_8, OS.LINUX),
+		assertThrows(UnsupportedOSException.class, () -> OS.MAC_UNKNOWN.enforce(OS.WIN_8, OS.LINUX),
 				"Did not throw even though OS was not allowed!");
-		assertDoesNotThrow(() -> OS.LINUX.enforceNot(OS.WIN_10, OS.MAC),
+		assertDoesNotThrow(() -> OS.LINUX.enforceNot(OS.WIN_10, OS.MAC_UNKNOWN),
 				"Threw even though OS was allowed!");
-		assertThrows(UnsupportedOSException.class, () -> OS.MAC.enforceNot(OS.MAC, OS.LINUX),
+		assertThrows(UnsupportedOSException.class, () -> OS.MAC_UNKNOWN.enforceNot(OS.MAC_UNKNOWN, OS.LINUX),
 				"Did not throw even though OS was not allowed!");
 	}
 
@@ -60,7 +60,7 @@ public class OSCheckTests {
 				OS.Family.OTHER), "Did not throw even though OS family was not allowed!");
 		assertDoesNotThrow(() -> OS.WIN_10.enforceNotFamily(OS.Family.MAC, OS.Family.LINUX),
 				"Threw even though OS family was allowed!");
-		assertThrows(UnsupportedOSException.class, () -> OS.MAC.enforceNotFamily(OS.Family.MAC,
+		assertThrows(UnsupportedOSException.class, () -> OS.MAC_UNKNOWN.enforceNotFamily(OS.Family.MAC,
 				OS.Family.OTHER), "Did not throw even though OS family was not allowed!");
 	}
 

--- a/src/test/java/io/github/cegredev/josi/OSNameTests.java
+++ b/src/test/java/io/github/cegredev/josi/OSNameTests.java
@@ -36,13 +36,11 @@ public class OSNameTests {
 	private static final String[] windowsNames = {"UNKNOWN:Windows fj12l3j123", "95:Windows 95", "98:Windows 98",
 			"XP:Windows XP", "VISTA:Windows Vista", "7:Windows 7", "8:Windows 8", "8_1:Windows 8.1", "10:Windows 10"};
 
-	private static final String[] macNames = {"MAC:Mac: ", "MAC:Mac:10", "MAC_OSX_CHEETAH:Mac OS X:10.0",
-	    "MAC_OSX_PUMA:Mac OS X:10.1.1", "MAC_OSX_JAGUAR:Mac:10.2.4", "MAC_OSX_PANTHER:Mac:10.3",
-	    "MAC_OSX_TIGER:Mac:10.4", "MAC_OSX_LEOPARD:Mac:10.5.1", "MAC_OSX_SNOW_LEOPARD:Mac:10.6",
-	    "MAC_OSX_LION:Mac:10.7", "MAC_OSX_MOUNTAIN_LION:Mac:10.8", "MAC_OSX_MAVERICKS:Mac:10.9",
-	    "MAC_OSX_YOSEMITE:Mac:10.10", "MAC_OSX_EL_CAPITAN:Mac:10.11", "MAC_OS_SIERRA:Mac:10.12",
-	    "MAC_OS_HIGH_SIERRA:Mac:10.13", "MAC_OS_MOJAVE:Mac:10.14.", "MAC_OS_CATALINA:Mac:10.15",
-	    "MAC_OS_BIG_SUR:Mac:10.16"};
+	private static final String[] macNames = {"UNKNOWN:Mac: ", "UNKNOWN:Mac:10", "OSX_CHEETAH:Mac OS X:10.0",
+			"OSX_PUMA:Mac OS X:10.1.1", "OSX_JAGUAR:Mac:10.2.4", "OSX_PANTHER:Mac:10.3", "OSX_TIGER:Mac:10.4",
+			"OSX_LEOPARD:Mac:10.5.1", "OSX_SNOW_LEOPARD:Mac:10.6", "OSX_LION:Mac:10.7", "OSX_MOUNTAIN_LION:Mac:10.8",
+			"OSX_MAVERICKS:Mac:10.9", "OSX_YOSEMITE:Mac:10.10", "OSX_EL_CAPITAN:Mac:10.11", "OS_SIERRA:Mac:10.12",
+			"OS_HIGH_SIERRA:Mac:10.13", "OS_MOJAVE:Mac:10.14.", "OS_CATALINA:Mac:10.15", "OS_BIG_SUR:Mac:10.16"};
 
 	private static final String[] linuxNames = {"LINUX:Linux"};
 
@@ -63,7 +61,7 @@ public class OSNameTests {
 		for (String os : macNames) {
 			String[] split = os.split(SEPARATOR);
 
-			assertEquals(OS.valueOf(split[0]), OS.determine(split[1], split[2]),
+			assertEquals(OS.valueOf("MAC_" + split[0]), OS.determine(split[1], split[2]),
 					"Did not determine correct OS for name.");
 		}
 	}

--- a/src/test/java/io/github/cegredev/josi/OSNameTests.java
+++ b/src/test/java/io/github/cegredev/josi/OSNameTests.java
@@ -36,7 +36,13 @@ public class OSNameTests {
 	private static final String[] windowsNames = {"UNKNOWN:Windows fj12l3j123", "95:Windows 95", "98:Windows 98",
 			"XP:Windows XP", "VISTA:Windows Vista", "7:Windows 7", "8:Windows 8", "8_1:Windows 8.1", "10:Windows 10"};
 
-	private static final String[] macNames = {":Mac"};
+	private static final String[] macNames = {"MAC:Mac: ", "MAC:Mac:10", "MAC_OSX_CHEETAH:Mac OS X:10.0",
+	    "MAC_OSX_PUMA:Mac OS X:10.1.1", "MAC_OSX_JAGUAR:Mac:10.2.4", "MAC_OSX_PANTHER:Mac:10.3",
+	    "MAC_OSX_TIGER:Mac:10.4", "MAC_OSX_LEOPARD:Mac:10.5.1", "MAC_OSX_SNOW_LEOPARD:Mac:10.6",
+	    "MAC_OSX_LION:Mac:10.7", "MAC_OSX_MOUNTAIN_LION:Mac:10.8", "MAC_OSX_MAVERICKS:Mac:10.9",
+	    "MAC_OSX_YOSEMITE:Mac:10.10", "MAC_OSX_EL_CAPITAN:Mac:10.11", "MAC_OS_SIERRA:Mac:10.12",
+	    "MAC_OS_HIGH_SIERRA:Mac:10.13", "MAC_OS_MOJAVE:Mac:10.14.", "MAC_OS_CATALINA:Mac:10.15",
+	    "MAC_OS_BIG_SUR:Mac:10.16"};
 
 	private static final String[] linuxNames = {"LINUX:Linux"};
 
@@ -47,7 +53,7 @@ public class OSNameTests {
 		for (String os : windowsNames) {
 			String[] split = os.split(SEPARATOR);
 
-			assertEquals(OS.valueOf("WIN_" + split[0]), OS.determine(split[1]),
+			assertEquals(OS.valueOf("WIN_" + split[0]), OS.determine(split[1], ""),
 					"Did not determine correct OS for name.");
 		}
 	}
@@ -57,7 +63,7 @@ public class OSNameTests {
 		for (String os : macNames) {
 			String[] split = os.split(SEPARATOR);
 
-			assertEquals(OS.valueOf("MAC" + split[0]), OS.determine(split[1]),
+			assertEquals(OS.valueOf(split[0]), OS.determine(split[1], split[2]),
 					"Did not determine correct OS for name.");
 		}
 	}
@@ -67,7 +73,8 @@ public class OSNameTests {
 		for (String os : linuxNames) {
 			String[] split = os.split(SEPARATOR);
 
-			assertEquals(OS.valueOf(split[0]), OS.determine(split[1]), "Did not determine correct OS for name.");
+			assertEquals(OS.valueOf(split[0]), OS.determine(split[1], ""),
+					"Did not determine correct OS for name.");
 		}
 	}
 
@@ -76,7 +83,8 @@ public class OSNameTests {
 		for (String os : otherNames) {
 			String[] split = os.split(SEPARATOR);
 
-			assertEquals(split[0], OS.determine(split[1]).toString(), "Did not determine correct OS for name.");
+			assertEquals(split[0], OS.determine(split[1], "").toString(),
+					"Did not determine correct OS for name.");
 		}
 	}
 


### PR DESCRIPTION
Hi! Really awesome library, I love how lightweight it is.

I wanted to contribute to adding specific versions of Mac OS.

From [this doc](https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html), I found the `os.version` property. For Mac, this returns a string in the form `10.x.x`. I matched that up to the version names from [here](https://en.wikipedia.org/wiki/MacOS_version_history#Releases).

Please let me know what you think!