### PR TITLE
Add macOS Monterey to OS enum

### DIFF
--- a/src/main/java/io/github/cegredev/josi/OS.java
+++ b/src/main/java/io/github/cegredev/josi/OS.java
@@ -56,6 +56,8 @@ public enum OS {
 	MAC_OSX_TIGER(MAC), MAC_OSX_LEOPARD(MAC), MAC_OSX_SNOW_LEOPARD(MAC), MAC_OSX_LION(MAC),
 	MAC_OSX_MOUNTAIN_LION(MAC), MAC_OSX_MAVERICKS(MAC), MAC_OSX_YOSEMITE(MAC), MAC_OSX_EL_CAPITAN(MAC),
 	MAC_OS_SIERRA(MAC), MAC_OS_HIGH_SIERRA(MAC), MAC_OS_MOJAVE(MAC), MAC_OS_CATALINA(MAC), MAC_OS_BIG_SUR(MAC),
+	MAC_OS_MONTEREY(MAC),
+
 	/**
 	 * An unknown or at least unrecognizable Mac based operating system.
 	 */
@@ -194,11 +196,16 @@ public enum OS {
 						case "16":
 							// Big Sur is macOS version 11.x, but sometimes 10.16 is returned
 							return MAC_OS_BIG_SUR;
+						case "17":
+							// Monterey is macOS version 12.x, but sometimes 10.17 is returned
+							return MAC_OS_MONTEREY;
 						default:
 							return MAC_UNKNOWN;
 					}
 				case "11":
 					return MAC_OS_BIG_SUR;
+				case "12":
+					return MAC_OS_MONTEREY;
 				default:
 					return MAC_UNKNOWN;
 			}

--- a/src/test/java/io/github/cegredev/josi/OSNameTests.java
+++ b/src/test/java/io/github/cegredev/josi/OSNameTests.java
@@ -53,7 +53,8 @@ public class OSNameTests {
 			new MDT(MAC_OSX_EL_CAPITAN, "Mac", "10.11"), new MDT(MAC_OS_SIERRA, "Mac", "10.12"),
 			new MDT(MAC_OS_HIGH_SIERRA, "Mac", "10.13"), new MDT(MAC_OS_MOJAVE, "Mac", "10.14"),
 			new MDT(MAC_OS_CATALINA, "Mac", "10.15"), new MDT(MAC_OS_BIG_SUR, "Mac", "10.16"),
-			new MDT(MAC_OS_BIG_SUR, "Mac OS X", "11.0"), new MDT(MAC_OS_BIG_SUR, "Mac OS X", "11.2.1")};
+			new MDT(MAC_OS_BIG_SUR, "Mac OS X", "11.0"), new MDT(MAC_OS_BIG_SUR, "Mac OS X", "11.2.1"),
+			new MDT(MAC_OS_MONTEREY, "Mac OS X", "12.0"), new MDT(MAC_OS_MONTEREY, "Mac OS X", "10.17")};
 
 	private static final LDT[] LINUX_TESTS = {new LDT(LINUX_UNKNOWN, "unknown"), new LDT(DEBIAN, "debian"),
 			new LDT(UBUNTU, "ubuntu"), new LDT(GENTOO, "gentoo"), new LDT(LINUX_MINT, "linux_mint"),


### PR DESCRIPTION
macOS Monterey was announced yesterday. I can't actually test this yet since I don't have access, but this is macOS version 12.x. I'm assuming that sometimes java will return 10.17, similar to what they do for Big Sur.

Feel free to merge or wait until Monterey is publicly available.